### PR TITLE
Small bug fix

### DIFF
--- a/crimsobot/cogs/games.py
+++ b/crimsobot/cogs/games.py
@@ -494,7 +494,6 @@ class Games(commands.Cog):
                             """
                     )
                     await ctx.send(embed=embed)
-                    await join_request.delete()
 
         # if no one joins, end game
         if len(users_already_joined) == 0:


### PR DESCRIPTION
Small remnant from old cringo join mechanism caused crash if bot tried to DM instructions to user who did not allow DMs.