### PR TITLE
Cringo! exploit fixed

### DIFF
--- a/crimsobot/utils/tools.py
+++ b/crimsobot/utils/tools.py
@@ -9,6 +9,20 @@ log = logging.getLogger(__name__)
 Messageables = Union[DMChannel, GroupChannel, Member, TextChannel, User]
 
 
+class UserAlreadyJoined(Exception):
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = None
+
+    def __str__(self):
+        if self.message:
+            return 'UserAlreadyJoined, {0} '.format(self.message)
+        else:
+            return 'UserAlreadyJoined: user already using function'
+
+
 def checkin(cmd: str, guild: Guild, channel: Messageables, running: List[int]) -> bool:
     """Is game already running in channel/DM?"""
 
@@ -22,7 +36,7 @@ def checkin(cmd: str, guild: Guild, channel: Messageables, running: List[int]) -
     else:
         guild_name = '*'
 
-    log.info('%s running on %s/%s (%s)...', cmd, guild_name, channel, channel.id)
+    # log.info('%s running on %s/%s (%s)...', cmd, guild_name, channel, channel.id)
 
     return True
 
@@ -37,7 +51,7 @@ def checkout(cmd: str, guild: Guild, channel: Messageables, running: List[int]) 
     else:
         guild_name = '*'
 
-    log.info('%s COMPLETE on %s/%s!', cmd, guild_name, channel)
+    # log.info('%s COMPLETE on %s/%s!', cmd, guild_name, channel)
 
 
 def crimbed(title: Optional[str], description: Optional[str], thumbnail: Optional[str] = None,


### PR DESCRIPTION
A user found an exploit in Cringo! where, by starting _n_ games at once and simply by joining one of them, the user could play _n_ games at once in a less-than-honest manner, as detailed below:

> So first I noticed that cringo can be exploited that it can run several instances of a game at the same time. When I type >cringo in n text channels, and then press join emoji it gives me n cards (also there is a bug with this, I only need to press join emoji on one channel, and it join me for a game in all channels)
> next thing is that the dm commands (.a1 . b2 etc) are sharable between all games, for example if a1 is a match on one card and not on the second the command still recognizes it on both cards, no way on describe on what card I wanted to put a match command on
> then because I can put several match command after one dot I just started to type in . a1 a2 a3 a4 b1 b2 b3 b4 c1 c2 c3 c4 d1 d2 d3 d4
> this way I was able to easely match cards with a little of points loss (<=16)
> 
> and then the horrible thing happened :grin:, I noticed that the crimsocoin amount is the same across all the servers
> this is when I tryed my "experiment" I invited crimsobot to an empty server and tryed run 10 instances of cringo by creating 10 text channels and type >cringo in each one
> this way I was able to generate 1 235,68 crimsocoin easely

This fix addresses the issue in two ways:
1. Adding a logical test to the join_cringo() check function to ensure that a user, by reacting to the join_message, can only join the game in the channel where the join_message was sent. This fixes the exploit detailed above.
2. Re-implementing tools.checkin() to not allow a user to play multiple games at once. This closes off the potential exploit where someone could start _n_ games, react to all of them, and play Cringo! with _n_ cards.